### PR TITLE
Add phpcs to composers dev-requirements...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,8 @@ web/themes/custom/com4dev/assets
 web/styleguide
 
 libphp7.so
+
+# Ignore files only for this boilerplate.
+# Remove for usage in production!
+/web
+composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,6 @@ web/styleguide
 libphp7.so
 
 # Ignore files only for this boilerplate.
-# Remove for usage in production!
+# ⚠️ Remove the following lines for usage in production ⚠️
 /web
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     "require-dev": {
         "behat/mink": "~1.7",
         "behat/mink-goutte-driver": "~1.2",
+        "drupal/coder": "^8.2",
         "jcalderonzumba/gastonjs": "~1.0.2",
         "jcalderonzumba/mink-phantomjs-driver": "~0.3.1",
         "mikey179/vfsstream": "~1.2",
@@ -60,7 +61,8 @@
             "DrupalProject\\composer\\ScriptHandler::checkComposerVersion"
         ],
         "post-install-cmd": [
-            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
+            "./vendor/bin/phpcs --config-set installed_paths ../../drupal/coder/coder_sniffer"
         ],
         "post-update-cmd": [
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
@@ -74,6 +76,11 @@
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],
             "web/themes/contrib/{$name}": ["type:drupal-theme"],
             "drush/contrib/{$name}": ["type:drupal-drush"]
+        },
+        "scripts-dev": {
+            "post-install-cmd": [
+                "phpcs --config-set installed_paths ../../drupal/coder/coder_sniffer"
+            ]
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -76,11 +76,6 @@
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],
             "web/themes/contrib/{$name}": ["type:drupal-theme"],
             "drush/contrib/{$name}": ["type:drupal-drush"]
-        },
-        "scripts-dev": {
-            "post-install-cmd": [
-                "phpcs --config-set installed_paths ../../drupal/coder/coder_sniffer"
-            ]
         }
     }
 }


### PR DESCRIPTION
...and remove some unused files via gitignore for testing what `composer` is doing locally.

Now you can use phpcs for check codestyles in your drupal projects. After `composer install`, just use:
`$ vendor/bin/phpcs --colors --standard=Drupal,DrupalPractice web/modules/custom`