### PR TITLE
Add new required module, example files & instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,61 @@
 # Drupal 8 Boilerplate
 
 We use this basic boilerplate to set up our Drupal 8 projects.
+
+## Installation / Setup
+
+We are using composer for installing drupal.
+
+### Get your packages
+Install Drupal via composer:
+
+    $ composer install 
+
+### Create drupal-specific files
+You can find our small library with some basic files for your setup in the folder `./examples`.
+You can copy them to its original location. Probably you have to adapt its content first.
+
+| Example File | Target Location | Enable? |
+| --- | --- | --- |
+| `./examples/settings.local.php` | `./web/sites/default/settings.local.php` | **YES**, in `./web/sites/default/settings.php` |
+| `./examples/development.services.yml` | `./web/sites/development.services.yml` (file exists already) | **YES**, in `./web/sites/default/settings.php` |
+
+### Connect the database
+Create database, setup the default drupal-installation, add the database-connection to the `./web/sites/default/settings.local.php`.
+
+### Drupal installation
+Install and uninstall (not) required modules directly with `drush`.
+
+    $ cd ./web
+    $ drush st
+
+Deinstallation of unused modules
+
+    $ drush pmu field_layout -y
+    $ drush pmu layout_discovery -y
+
+Installation of new modules
+
+    $ drush en admin_toolbar -y
+    $ drush en admin_toolbar_tools -y
+    $ drush en environment_indicator -y
+    $ drush en field_group -y
+    $ drush en metatag -y
+    $ drush en redirect -y
+    $ drush en twig_field_value -y
+    
+## Optional Addons
+Based on your project, you can use some default addons.
+
+### Paragraphs
+[Paragraphs module]([Drupal Composer](https://www.drupal.org/docs/develop/using-composer/using-composer-with-drupal))
+
+A module to add a new possibility to create content. 
+
+    $ composer require drupal/paragraphs
+    $ composer require drupal/paragraphs_edit
+    
+    $ cd ./web
+    
+    $ drush en paragraphs -y
+    $ drush en paragraphs_edit -y

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "drupal/admin_toolbar": "^1.19",
         "drupal/console": "^1.0.1",
         "drupal/core": "~8.0",
+        "drupal/environment_indicator": "^3.2",
         "drupal/field_group": "^1.0@RC",
         "drupal/metatag": "^1.3",
         "drupal/redirect": "^1.0@beta",

--- a/examples/development.services.yml
+++ b/examples/development.services.yml
@@ -1,0 +1,12 @@
+# Local development services. Disable cache & enable twig-debug for your local environment.
+#
+# Activate this file in your "settings.php"
+parameters:
+  http.response.debug_cacheability_headers: true
+  twig.config:
+    debug: true
+    auto_reload: true
+    cache: false
+services:
+  cache.backend.null:
+    class: Drupal\Core\Cache\NullBackendFactory

--- a/examples/settings.local.php
+++ b/examples/settings.local.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @file
+ * Some settings specific for this local environment.
+ *
+ * If you want you can add the content of this file to the basic settings.php,
+ * or you can leave it here. Some settings are specific for the local
+ * environment and you have to adapt it to other environments with
+ * different content.
+ *
+ * Questions? <hello@gridonic.ch>
+ */
+// Disable some caches.
+// ⚠️ Works together with "development.services.yml"
+$settings['cache']['bins']['render'] = 'cache.backend.null';
+$settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
+
+// Settings for drupal-module "environment_indicator".
+$config['environment_indicator.indicator']['bg_color'] = '#014F01';
+$config['environment_indicator.indicator']['fg_color'] = '#ffffff';
+$config['environment_indicator.indicator']['name'] = 'Local';


### PR DESCRIPTION
I have added the required module `environment_indicator`.

Additionally some example files (settings.local.php, development.services.yml) and added instructions for the first installation to the readme file.
