### PR TITLE
prevent errors during composer post-install-cmd

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         ],
         "post-install-cmd": [
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
-            "test -e ./vendor/bin/phpcs && ./vendor/bin/phpcs --config-set installed_paths ../../drupal/coder/coder_sniffer || echo no phpcs found - installed_paths not set"
+            "test -e ./vendor/bin/phpcs && ./vendor/bin/phpcs --config-set installed_paths ../../drupal/coder/coder_sniffer || echo 'no phpcs found - installed_paths not set'"
         ],
         "post-update-cmd": [
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         ],
         "post-install-cmd": [
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
-            "./vendor/bin/phpcs --config-set installed_paths ../../drupal/coder/coder_sniffer"
+            "test -e ./vendor/bin/phpcs && ./vendor/bin/phpcs --config-set installed_paths ../../drupal/coder/coder_sniffer || echo no phpcs found - installed_paths not set"
         ],
         "post-update-cmd": [
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"


### PR DESCRIPTION
There is the possibility to install the composer packages without the `require-dev` part. In this case, `./vendor/bin/phpcs` is not available and the `post-install-cmd` will fail.