### PR TITLE
Add pathauto module

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Deinstallation of unused modules
 
     $ drush pmu field_layout -y
     $ drush pmu layout_discovery -y
+    $ drush pmu contact -y
 
 Installation of new modules
 
@@ -61,6 +62,7 @@ Installation of new modules
     $ drush en metatag -y
     $ drush en redirect -y
     $ drush en twig_field_value -y
+    $ drush en pathauto -y
     
 ## Coding standards
 

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "drupal/environment_indicator": "^3.2",
         "drupal/field_group": "^1.0@RC",
         "drupal/metatag": "^1.3",
+        "drupal/pathauto": "^1.1",
         "drupal/redirect": "^1.0@beta",
         "drupal/twig_field_value": "^1.1",
         "drush/drush": "~8.0",


### PR DESCRIPTION
Adds `pathauto` module to the default module stack. 

I was wondering where we draw the line between a required and optional module like Paragraphs. Would it not make sense to also include optional modules in our boilerplate and leave them uninstalled if the project does not require them? I think there are are other modules we need on 80% of our sites like:

* Simple XML sitemap
* Google Analytics
* Views Reference

So my suggestion would be to include them but leave the installation optional. 